### PR TITLE
Add rust and cpp and alphabetize the languages list

### DIFF
--- a/README
+++ b/README
@@ -20,4 +20,4 @@ To build all modules at once, run
 
 This gives you C, JSON, Go, HTML, Javascript, CSS, Python, Typescript,
 C#, C++, Rust. More can be added to batch.sh unless it's directory
-strucure is not standard.
+structure is not standard.


### PR DESCRIPTION
I also reworded the statement in the README since the languages are defined clearly in `batch.sh` and we avoid having to maintain 2 lists. Can drop that commit if you want.

BTW I noticed that the typescript module doesn't seem to build like the others. I don't see any typescript `.so` file in `dist` and in the root directory I see a `tree-sitter-typescript` directory. There is a `dist` directory inside the `tree-sitter-typescript` directory with the `.so` file. Is that expected?

Another thing: I see there are old build and batch files. Any reason why they're being kept around or can they be removed?