### PR TITLE
Remove dist directory before building batch.

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -16,6 +16,11 @@ languages=(
     'heex'
 )
 
+if [ -e dist ]
+then
+    rm -rf dist
+fi
+
 for language in "${languages[@]}"
 do
     ./build.sh $language


### PR DESCRIPTION
This avoids keeping libraries built previously that are no longer part of the batch script.