### PR TITLE
Cache parser repos locally to avoid re-cloning on each build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,7 @@
 set -u
 set -e
 
-lang=$1
-topdir="$PWD"
-
-if [ "$(uname)" == "Darwin" ]
+if [ "$(uname)" = "Darwin" ]
 then
     soext="dylib"
 elif uname | grep -q "MINGW" > /dev/null
@@ -16,14 +13,30 @@ else
     soext="so"
 fi
 
+# Target language to build a parser for
+lang=$1
+# Base directory containing this project
+topdir="$PWD"
+# Base directory to clone the parser repository to
+repodir="$topdir/repos"
+# Base directory to copy parser libraries to after building
+parserdir="$topdir/dist"
+# Filename of the parser library for ${lang}
+langparser="libtree-sitter-$lang.$soext"
+
 echo "Building ${lang}"
 
 ### Retrieve sources
 
+# GitHub organisation hosting the parser for ${lang}
 org="tree-sitter"
+# GitHub repository in ${org} hosting the parser for ${lang}
 repo="tree-sitter-${lang}"
-sourcedir="tree-sitter-${lang}/src"
-grammardir="tree-sitter-${lang}"
+
+# Subdirectory within ${sourcedir} containing parser source files for ${lang}
+parsersubdir="src"
+# Subdirectory within ${sourcedir} containing a grammar.js file for ${lang}
+grammarsubdir=""
 
 case "${lang}" in
     "dockerfile")
@@ -33,13 +46,13 @@ case "${lang}" in
         org="uyha"
         ;;
     "typescript")
-        sourcedir="tree-sitter-typescript/typescript/src"
-        grammardir="tree-sitter-typescript/typescript"
+        parsersubdir="typescript/src"
+        grammarsubdir="typescript"
         ;;
     "tsx")
         repo="tree-sitter-typescript"
-        sourcedir="tree-sitter-typescript/tsx/src"
-        grammardir="tree-sitter-typescript/tsx"
+        parsersubdir="tsx/src"
+        grammarsubdir="tsx"
         ;;
     "elixir")
         org="elixir-lang"
@@ -82,12 +95,37 @@ case "${lang}" in
         ;;
 esac
 
-git clone "https://github.com/${org}/${repo}.git" \
-    --depth 1 --quiet
-cp "${grammardir}"/grammar.js "${sourcedir}"
+# Local directory to clone parser repository to
+sourcedir="${repodir}/${org}/${repo}"
+
+if [ -e "$sourcedir" ]
+then
+    # Already cloned, check if needs to be updated and rebuilt.
+    git -C "${sourcedir}" remote update
+    if [ -n "$(git -C "${sourcedir}" diff origin --numstat)" ]
+    then
+        git -C "${sourcedir}" merge --ff-only origin
+        # Removing the existing parser from the previous build to ensure if
+        # building it fails we don't just keep using an out of date parser.
+        rm "${parserdir}/${langparser}"
+    elif [ -e "${parserdir}/${langparser}" ]
+    then
+        echo "Skipping ${lang}" >&2
+        exit 0
+    fi
+else
+    git clone "https://github.com/${org}/${repo}.git" --depth 1 --quiet "${sourcedir}"
+fi
+
 # We have to go into the source directory to compile, because some
 # C files refer to files like "../../common/scanner.h".
-cd "${sourcedir}"
+cd "${sourcedir}/${parsersubdir}"
+
+# Ensure the grammar.js file exists for the parser build.
+if ! [ -e grammar.js ]
+then
+    ln -sf "${sourcedir}/${grammarsubdir}"/grammar.js ./
+fi
 
 ### Build
 
@@ -105,14 +143,12 @@ fi
 # Link.
 if test -f scanner.cc
 then
-    c++ -fPIC -shared *.o -o "libtree-sitter-${lang}.${soext}"
+    c++ -fPIC -shared *.o -o "${langparser}"
 else
-    cc -fPIC -shared *.o -o "libtree-sitter-${lang}.${soext}"
+    cc -fPIC -shared *.o -o "${langparser}"
 fi
 
 ### Copy out
 
-mkdir -p "${topdir}/dist"
-cp "libtree-sitter-${lang}.${soext}" "${topdir}/dist"
-cd "${topdir}"
-rm -rf "${repo}"
+mkdir -p "${parserdir}"
+cp "${langparser}" "${parserdir}"


### PR DESCRIPTION
Hi,

I noticed we clone and then just delete the parser repository each time we try to build the parser for a language. This seems a little excessive and makes batch rebuilding with `./batch.sh` integrated into straight or another tool very slow. I've made some amendments to improve the build time of this project. 

+ Now we clone all repos into a repos/ sub-directory which we persist across rebuilds.
+ When building a project we fetch from the remote to see if anythings changed, if it has we pull from the remote, removing the local parser and continue building. If not we skip the clone and the pull altogether and don't bother rebuilding when nothing has changed.

This should have a noticeable improvement in build time. Not huge, because there's still a network request that has to go out on each build attempt but an improvement all the same. I'll work on supporting parallelized builds for all parsers in another PR.