### PR TITLE
Add tree-sitter-scss

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -11,6 +11,7 @@ languages=(
     'cmake'
     'cpp'
     'css'
+    'scss'
     'dockerfile'
     'elisp'
     'elixir'

--- a/build.sh
+++ b/build.sh
@@ -91,6 +91,9 @@ case "${lang}" in
     "clojure")
         org="dannyfreeman"
         ;;
+    "scss")
+        org="serenadeai"
+        ;;
 esac
 
 if [ -z "$branch" ]


### PR DESCRIPTION
Hi, I am a heavy user of SCSS, really want to have this module added. It appears that Emacs 29 doesn't come with a built-in `scss-ts-mode`. I am trying to create one.