### PR TITLE
Add Verilog support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,6 +120,9 @@ case "${lang}" in
         site="https://gitlab.com"
         org="btuin2"
         ;;
+    "verilog")
+        org="gmlarumbe"
+        ;;
 esac
 
 if [ -z "$branch" ]


### PR DESCRIPTION
Hi,

This PR adds the Verilog grammar from my current fork.

It is the one used by [`verilog-ts-mode`](https://github.com/gmlarumbe/verilog-ts-mode) as the [official one](https://github.com/tree-sitter/tree-sitter-verilog) lacks support for some language constructs.

Thanks!