### PR TITLE
Rename gomod language

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -17,7 +17,7 @@ languages=(
     'elixir'
     'glsl'
     'go'
-    'go-mod'
+    'gomod'
     'heex'
     'html'
     'janet-simple'

--- a/build.sh
+++ b/build.sh
@@ -89,8 +89,9 @@ case "${lang}" in
     "yaml")
         org="ikatyang"
         ;;
-    "go-mod")
+    "gomod")
         org="camdencheek"
+        repo="tree-sitter-go-mod"
         ;;
     "clojure")
         org="sogaiu"


### PR DESCRIPTION
Fixes #41

Renaming the repo is not strictly necessary, as there is a redirect from https://github.com/camdencheek/tree-sitter-gomod to https://github.com/camdencheek/tree-sitter-go-mod, but it's probably best not to rely on that. The repo with the hyphen is the canonical one.