### PR TITLE
Pin tree-sitter-cpp to v0.22.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,9 @@ case "${lang}" in
     "clojure")
         org="sogaiu"
         ;;
+    "cpp")
+        branch="v0.22.0"
+        ;;
     "cmake")
         org="uyha"
         ;;


### PR DESCRIPTION
This commit pins the tree-sitter-cpp dependency to version 0.22.0. Versions beyond 0.22.0 introduce a compatibility issue with Emacs.

This pin will remain in effect until the issue is addressed by the Emacs project.

For detailed information about the compatibility issue, please refer to the following GitHub issue:
https://github.com/tree-sitter/tree-sitter-cpp/issues/271