### PR TITLE
Add new grammars url and doxygen

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -16,6 +16,7 @@ languages=(
     'css'
     'dart'
     'dockerfile'
+    'doxygen'
     'elisp'
     'elixir'
     'erlang'

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,9 @@ case "${lang}" in
     "dockerfile")
         org="camdencheek"
         ;;
+    "doxygen")
+        org="tree-sitter-grammars"
+        ;;
     "elisp")
         org="Wilfred"
         ;;
@@ -55,7 +58,7 @@ case "${lang}" in
         org="WhatsApp"
         ;;
     "glsl")
-        org="theHamsta"
+        org="tree-sitter-grammars"
         ;;
     "gomod")
         org="camdencheek"
@@ -71,16 +74,17 @@ case "${lang}" in
         org="fwcd"
         ;;
     "lua")
-        org="MunifTanjim"
+        org="tree-sitter-grammars"
         ;;
     "magik")
         org="krn-robin"
         ;;
     "make")
-        org="alemuller"
+        org="tree-sitter-grammars"
         ;;
     "markdown")
-        org="ikatyang"
+        org="tree-sitter-grammars"
+        sourcedir="tree-sitter-markdown/src"
         ;;
     "org")
         org="milisims"
@@ -95,7 +99,7 @@ case "${lang}" in
         org="mitchellh"
         ;;
     "scss")
-        org="serenadeai"
+        org="tree-sitter-grammars"
         ;;
     "souffle")
         org="chaosite"
@@ -108,7 +112,7 @@ case "${lang}" in
         org="connorlay"
         ;;
     "toml")
-        org="ikatyang"
+        org="tree-sitter-grammars"
         ;;
     "tsx")
         repo="tree-sitter-typescript"
@@ -133,7 +137,7 @@ case "${lang}" in
         org="mehmetoguzderin"
         ;;
     "yaml")
-        org="ikatyang"
+        org="tree-sitter-grammars"
         ;;
     "zig")
         org="maxxnino"


### PR DESCRIPTION
Use the repositories in [tree-sitter-grammars](https://github.com/orgs/tree-sitter-grammars/repositories) for:
glsl, lua, make, markdown, scss, toml and yaml
fixes #53
Add doxygen as it is already supported by c-ts-mode and c++-ts-mode.
fixes #52