### PR TITLE
Add support for building subset of languages in parallel.

### DIFF
--- a/README
+++ b/README
@@ -26,3 +26,7 @@ a PR.
 You can enable parallel build with the JOBS variable, like this:
 
     JOBS=8 ./batch.sh
+
+You can also enable parallel build for a subset of pre-defined languages:
+
+    JOBS=8 ./batch.sh c elisp rust zig

--- a/batch.sh
+++ b/batch.sh
@@ -71,6 +71,11 @@ languages=(
     'zig'
 )
 
+requested_languages=("$@")
+if (( ${#requested_languages[@]} != 0 )); then
+    languages=("${requested_languages[@]}")
+fi
+
 if [ -z "${JOBS:-}" ]
 then
     for language in "${languages[@]}"


### PR DESCRIPTION
This PR added support for building subset of pre-defined languages in the batch script.

E.g.,

```bash
JOBS=8 ./batch.sh c elisp rust zig
```